### PR TITLE
DS-3109 Add attribute for iframeless widget

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,11 +1,11 @@
 Package: rhtmlPictographs
 Type: Package
 Title: Create Pictograph html widgets
-Version: 1.0.0
+Version: 1.0.1
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: An R HTMLWidget that can generate single image graphics, mutli
     image graphics, or a table of single/multi image graphics
 License: GPL-3
 LazyData: TRUE
-RoxygenNote: 6.1.1
+RoxygenNote: 7.1.1

--- a/R/rhtmlPictographs.R
+++ b/R/rhtmlPictographs.R
@@ -35,8 +35,7 @@ graphic <- function(settingsJsonString = '{}') {
     package = 'rhtmlPictographs'
   )
   # Adding this attribute allows the widget to be used without being embedded in an iframe
-  # See DS-3019 and the related epic of RS-6897
-  p <- print(g)
-  attr(p, "can-run-in-root-dom") <- TRUE
-  p
+  # See DS-3109 and the related epic of RS-6897
+  attr(g, "can-run-in-root-dom") <- TRUE
+  g
 }

--- a/R/rhtmlPictographs.R
+++ b/R/rhtmlPictographs.R
@@ -24,7 +24,7 @@
 #'
 
 graphic <- function(settingsJsonString = '{}') {
-  htmlwidgets::createWidget(
+  g <- htmlwidgets::createWidget(
     name = 'rhtmlPictographs',
     settingsJsonString,
     sizingPolicy = htmlwidgets::sizingPolicy(
@@ -34,4 +34,8 @@ graphic <- function(settingsJsonString = '{}') {
     ),
     package = 'rhtmlPictographs'
   )
+  # Adding this attribute allows the widget to be used without being embedded in an iframe
+  # See DS-3019 and the related epic of RS-6897
+  attr(g, "can-run-in-root-dom") <- TRUE
+  g
 }

--- a/R/rhtmlPictographs.R
+++ b/R/rhtmlPictographs.R
@@ -36,6 +36,7 @@ graphic <- function(settingsJsonString = '{}') {
   )
   # Adding this attribute allows the widget to be used without being embedded in an iframe
   # See DS-3019 and the related epic of RS-6897
-  attr(g, "can-run-in-root-dom") <- TRUE
-  g
+  p <- print(g)
+  attr(p, "can-run-in-root-dom") <- TRUE
+  p
 }

--- a/theSrc/R/htmlwidget.R
+++ b/theSrc/R/htmlwidget.R
@@ -24,7 +24,7 @@
 #'
 
 graphic <- function(settingsJsonString = '{}') {
-  htmlwidgets::createWidget(
+  g <- htmlwidgets::createWidget(
     name = 'rhtmlPictographs',
     settingsJsonString,
     sizingPolicy = htmlwidgets::sizingPolicy(
@@ -34,4 +34,8 @@ graphic <- function(settingsJsonString = '{}') {
     ),
     package = 'rhtmlPictographs'
   )
+  # Adding this attribute allows the widget to be used without being embedded in an iframe
+  # See DS-3109 and the related epic of RS-6897
+  attr(g, "can-run-in-root-dom") <- TRUE
+  g
 }


### PR DESCRIPTION
Added the attribute "can-run-in-root-dom" that takes the value TRUE to
the htmlwidget when used in the call to graphic. This has the effect of
removing the iframe from the html code so the widget is no longer 
embedded in an iframe.
