### PR TITLE
DPI-2925 Package rhtmlPictographs in nix

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,14 @@
+{ pkgs ? import <nixpkgs> {}, displayrUtils }:
+
+pkgs.rPackages.buildRPackage {
+  name = "rhtmlPictographs";
+  version = displayrUtils.extractRVersion (builtins.readFile ./DESCRIPTION); 
+  src = ./.;
+  description = ''
+    An R HTMLWidget that can generate single image graphics, mutli
+    image graphics, or a table of single/multi image graphics
+  '';
+  propagatedBuildInputs = with pkgs.rPackages; [ 
+    htmlwidgets
+  ];
+}


### PR DESCRIPTION
As part of the R Server CI/CD uplift, this task is to package rhtmlPictographs in Nix to make R server CI/CD more reliable and reproducible. To build it, see https://github.com/Displayr/NixR